### PR TITLE
Add new options to query mongo [CM-319]

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ const LOG_OPERATORS = {
   or: '$or',
 };
 
-const FILTERS_KEYWORDS = ['page', 'limit', 'sort', '_op'];
+const FILTERS_KEYWORDS = ['page', 'limit', 'sort', '_op', '_fields'];
 
 const castValues = (value) => {
   if (value === 'null') {
@@ -63,6 +63,19 @@ const getOperator = (query) => {
   return LOG_OPERATORS[_op] ? LOG_OPERATORS[_op] : LOG_OPERATORS.and;
 };
 
+const getFields = (query) => {
+  const { _fields } = query;
+  if(!_fields) {
+    return undefined
+  }
+
+  return _fields.split(',').reduce((acc, field) => {
+    acc[field.trim()] = 1;
+    return acc;
+  }, {});
+
+}
+
 const transformSort = (sort) => {
   const regex = /^(.*?)(?:\s(ASC|DESC))?$/;
   if (!sort) {
@@ -82,11 +95,13 @@ class QueryBuilder {
     const filters = getFilters(query);
     const pagination = getPagination(query);
     const sort = getSort(query);
+    const fields = getFields(query);
 
     return {
       pagination,
       filters,
       sort,
+      fields,
     };
   }
 }

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ const LOG_OPERATORS = {
   or: '$or',
 };
 
-const FILTERS_KEYWORDS = ['page', 'limit', 'sort', 'op'];
+const FILTERS_KEYWORDS = ['page', 'limit', 'sort', '_op'];
 
 const castValues = (value) => {
   if (value === 'null') {
@@ -25,7 +25,7 @@ const castValues = (value) => {
 
 const getFilters = (query) => {
   const operator = getOperator(query);
-  return Object.keys(query)
+  const filters = Object.keys(query)
     .filter(key => !FILTERS_KEYWORDS.includes(key))
     .reduce((acc, key) => {
       const field = key.split('.');
@@ -36,6 +36,8 @@ const getFilters = (query) => {
       acc[operator].push({ [field.join('.')]: filter })
       return acc;
     }, { [operator] : [] });
+
+  return filters[operator].length ? filters : {};
 };
 
 const getPagination = (query) => {
@@ -57,8 +59,8 @@ const getSort = (query) => (
 );
 
 const getOperator = (query) => {
-  const { op='and' } = query;
-  return LOG_OPERATORS[op] ? LOG_OPERATORS[op] : LOG_OPERATORS.and;
+  const { _op='and' } = query;
+  return LOG_OPERATORS[_op] ? LOG_OPERATORS[_op] : LOG_OPERATORS.and;
 };
 
 const transformSort = (sort) => {

--- a/index.test.js
+++ b/index.test.js
@@ -214,4 +214,34 @@ describe('Query Builder', () => {
       expect(result).to.be.undefined;
     });
   });
+
+
+  describe('fields', function() {
+    it('selects single field', () => {
+      const query = { _fields: 'OrderId' };
+
+      const result = QueryBuilder.build(query).fields;
+      const expected = { OrderId:  1 };
+
+      expect(result).to.eql(expected);
+    });
+
+    it('selects multiple fields', () => {
+      const query = { _fields: 'OrderId, Name' };
+
+      const result = QueryBuilder.build(query).fields;
+      const expected = { OrderId:  1, Name: 1 };
+
+      expect(result).to.eql(expected);
+    });
+
+    it('return undefined when no fields', function() {
+      const query = {};
+
+      const result = QueryBuilder.build(query).fields;
+      const expected = undefined;
+
+      expect(result).to.eql(expected);
+    });
+  });
 });

--- a/index.test.js
+++ b/index.test.js
@@ -45,7 +45,7 @@ describe('Query Builder', () => {
       const query = { 'Person.FirstName.eq': 'John', 'Person.LastName.eq': 'Snow' };
 
       const result = QueryBuilder.build(query).filters;
-      const expected = { 'Person.FirstName': { $eq: 'John' }, 'Person.LastName': { $eq: 'Snow' } };
+      const expected = { $and : [{ 'Person.FirstName': { $eq: 'John' } },{ 'Person.LastName': { $eq: 'Snow' } }] };
 
       expect(result).to.eql(expected);
     });
@@ -54,8 +54,7 @@ describe('Query Builder', () => {
       const query = { 'firstName.eq': 'John', page: 1, limit: 10 };
 
       const result = QueryBuilder.build(query).filters;
-      const expected = { firstName: { $eq: 'John' } };
-
+      const expected = { $and: [ {firstName: { $eq: 'John' }} ] };
       expect(result).to.eql(expected);
     });
 
@@ -63,7 +62,7 @@ describe('Query Builder', () => {
       const query = { 'firstName.eq': 'John', sort: 'Status' };
 
       const result = QueryBuilder.build(query).filters;
-      const expected = { firstName: { $eq: 'John' } };
+      const expected = { $and: [{firstName: { $eq: 'John' }}] };
 
       expect(result).to.eql(expected);
     });
@@ -72,7 +71,7 @@ describe('Query Builder', () => {
       const query = { 'firstName.eq': 'John', 'lastName.eq': 'Snow' };
 
       const result = QueryBuilder.build(query).filters;
-      const expected = { firstName: { $eq: 'John' }, lastName: { $eq: 'Snow' } };
+      const expected = { $and:[ {firstName: { $eq: 'John' }}, {lastName: { $eq: 'Snow' }} ]};
 
       expect(result).to.eql(expected);
     });
@@ -81,7 +80,7 @@ describe('Query Builder', () => {
       const query = { firstName: 'John', lastName: 'Snow' };
 
       const result = QueryBuilder.build(query).filters;
-      const expected = { firstName: { $eq: 'John' }, lastName: { $eq: 'Snow' } };
+      const expected = { $and: [ {firstName: { $eq: 'John' }}, {lastName: { $eq: 'Snow' }} ] };
 
       expect(result).to.eql(expected);
     });
@@ -90,7 +89,7 @@ describe('Query Builder', () => {
       const query = { 'firstName.ne': 'oh' };
 
       const result = QueryBuilder.build(query).filters;
-      const expected = { firstName: { $ne: 'oh' } };
+      const expected = { $and: [{firstName: { $ne: 'oh' }}]  };
 
       expect(result).to.eql(expected);
     });
@@ -99,7 +98,7 @@ describe('Query Builder', () => {
       const query = { 'firstName.lt': 'oh' };
 
       const result = QueryBuilder.build(query).filters;
-      const expected = { firstName: { $lt: 'oh' } };
+      const expected = { $and: [{ firstName: { $lt: 'oh' } }]  };
 
       expect(result).to.eql(expected);
     });
@@ -108,7 +107,7 @@ describe('Query Builder', () => {
       const query = { 'firstName.lte': 'oh' };
 
       const result = QueryBuilder.build(query).filters;
-      const expected = { firstName: { $lte: 'oh' } };
+      const expected = { $and: [{firstName: { $lte: 'oh' }}]  };
 
       expect(result).to.eql(expected);
     });
@@ -117,7 +116,7 @@ describe('Query Builder', () => {
       const query = { 'Person.firstName.gt': 'oh' };
 
       const result = QueryBuilder.build(query).filters;
-      const expected = { 'Person.firstName': { $gt: 'oh' } };
+      const expected = { $and : [{ 'Person.firstName': { $gt: 'oh' } }] };
 
       expect(result).to.eql(expected);
     });
@@ -126,7 +125,7 @@ describe('Query Builder', () => {
       const query = { 'Person.firstName.gte': 'oh' };
 
       const result = QueryBuilder.build(query).filters;
-      const expected = { 'Person.firstName': { $gte: 'oh' } };
+      const expected = { $and: [ { 'Person.firstName': { $gte: 'oh' } } ] };
 
       expect(result).to.eql(expected);
     });
@@ -135,7 +134,7 @@ describe('Query Builder', () => {
       const query = { 'Person.firstName.contains': 'oh' };
 
       const result = QueryBuilder.build(query).filters;
-      const expected = { 'Person.firstName': { $regex: 'oh', $options: 'i' } };
+      const expected = { $and: [ { 'Person.firstName': { $regex: 'oh', $options: 'i' } } ] };
 
       expect(result).to.eql(expected);
     });
@@ -144,7 +143,25 @@ describe('Query Builder', () => {
       const query = { 'Person.firstName.eq': 'null' };
 
       const result = QueryBuilder.build(query).filters;
-      const expected = { 'Person.firstName': { $eq: null } };
+      const expected = { $and : [ { 'Person.firstName': { $eq: null } } ] };
+
+      expect(result).to.eql(expected);
+    });
+
+    it('uses or operator', function() {
+      const query = { 'Person.firstName.eq': 'null', op: 'or' };
+
+      const result = QueryBuilder.build(query).filters;
+      const expected = { $or : [ { 'Person.firstName': { $eq: null } } ] };
+
+      expect(result).to.eql(expected);
+    });
+
+    it('sends invalid operator then uses $and', function() {
+      const query = { 'Person.firstName.eq': 'null', op: 'xor' };
+
+      const result = QueryBuilder.build(query).filters;
+      const expected = { $and : [ { 'Person.firstName': { $eq: null } } ] };
 
       expect(result).to.eql(expected);
     });

--- a/index.test.js
+++ b/index.test.js
@@ -40,6 +40,17 @@ describe('Query Builder', () => {
     });
   });
 
+  describe('no filters', function() {
+    it('does not create an empty array', () => {
+      const query = { };
+
+      const result = QueryBuilder.build(query).filters;
+      const expected = { };
+
+      expect(result).to.eql(expected);
+    });
+  });
+
   describe('filters', () => {
     it('selects filters case sensitve', () => {
       const query = { 'Person.FirstName.eq': 'John', 'Person.LastName.eq': 'Snow' };
@@ -149,7 +160,7 @@ describe('Query Builder', () => {
     });
 
     it('uses or operator', function() {
-      const query = { 'Person.firstName.eq': 'null', op: 'or' };
+      const query = { 'Person.firstName.eq': 'null', _op: 'or' };
 
       const result = QueryBuilder.build(query).filters;
       const expected = { $or : [ { 'Person.firstName': { $eq: null } } ] };
@@ -158,7 +169,7 @@ describe('Query Builder', () => {
     });
 
     it('sends invalid operator then uses $and', function() {
-      const query = { 'Person.firstName.eq': 'null', op: 'xor' };
+      const query = { 'Person.firstName.eq': 'null', _op: 'xor' };
 
       const result = QueryBuilder.build(query).filters;
       const expected = { $and : [ { 'Person.firstName': { $eq: null } } ] };


### PR DESCRIPTION
Added
 - _fields :  list of fields to be returned in payload
 - _op : logical operator `or` and `and` are valid options. `and` is the default value.